### PR TITLE
reduce allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ func Handle(rw http.ResponseWriter, req *http.Request) {
 	ctx, cancel := context.WithTimeout(req.Context(), time.Second)
 	defer cancel()
 
-	call := tracer.Fetch(req.Context()).Start().Mark(req.Header.Get("X-Request-Id"))
+	call := tracer.Fetch(req.Context()).Start(req.Header.Get("X-Request-Id"))
 	defer call.Stop()
 
 	...
 
-	call.Checkpoint().Mark("serialize")
+	call.Checkpoint("serialize")
 	data := FetchData(ctx, req.Body)
 
-	call.Checkpoint().Mark("store")
+	call.Checkpoint("store")
 	if err := StoreIntoDatabase(ctx, data); err != nil {
 		http.Error(rw,
 			http.StatusText(http.StatusInternalServerError),

--- a/context.go
+++ b/context.go
@@ -9,6 +9,6 @@ func Fetch(ctx context.Context) *Trace {
 	return trace
 }
 
-func Inject(ctx context.Context, stack []*Call) context.Context {
+func Inject(ctx context.Context, stack []Call) context.Context {
 	return context.WithValue(ctx, key{}, &Trace{stack: stack})
 }

--- a/context_test.go
+++ b/context_test.go
@@ -12,14 +12,14 @@ func TestContext(t *testing.T) {
 		if Fetch(context.Background()) != nil {
 			t.Error("expected nil")
 		}
-		Fetch(context.Background()).Start().Mark("no panic").Stop()
+		Fetch(context.Background()).Start("no panic").Stop()
 	})
 	t.Run("fetch injected", func(t *testing.T) {
 		ctx := Inject(context.Background(), nil)
 		if Fetch(ctx) == nil {
 			t.Error("unexpected nil")
 		}
-		Fetch(ctx).Start().Mark("allocation").Stop()
+		Fetch(ctx).Start("allocation").Stop()
 	})
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -48,7 +48,7 @@ func Example() {
 
 func InjectTracer(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		req = req.WithContext(tracer.Inject(req.Context(), make([]*tracer.Call, 0, 2)))
+		req = req.WithContext(tracer.Inject(req.Context(), make([]tracer.Call, 0, 2)))
 		handler.ServeHTTP(rw, req)
 	})
 }
@@ -64,7 +64,7 @@ func Handle(rw http.ResponseWriter, req *http.Request) {
 	ctx, cancel := context.WithTimeout(req.Context(), time.Second)
 	defer cancel()
 
-	call := tracer.Fetch(req.Context()).Start().Mark(req.Header.Get("X-Request-Id"))
+	call := tracer.Fetch(req.Context()).Start(req.Header.Get("X-Request-Id"))
 	defer call.Stop()
 
 	time.Sleep(time.Millisecond)

--- a/example_test.go
+++ b/example_test.go
@@ -69,7 +69,7 @@ func Handle(rw http.ResponseWriter, req *http.Request) {
 
 	time.Sleep(time.Millisecond)
 
-	call.Checkpoint().Mark("serialize")
+	call.Checkpoint("serialize")
 	data, err := FetchData(ctx, req.Body)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -78,7 +78,7 @@ func Handle(rw http.ResponseWriter, req *http.Request) {
 
 	time.Sleep(time.Millisecond)
 
-	call.Checkpoint().Mark("store")
+	call.Checkpoint("store")
 	if err := StoreIntoDatabase(ctx, data); err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return

--- a/helper_test.go
+++ b/helper_test.go
@@ -22,7 +22,7 @@ func callerC() CallerInfo {
 }
 
 func traceRoot(ctx context.Context) {
-	call := Fetch(ctx).Start().Mark("root")
+	call := Fetch(ctx).Start("root")
 	defer call.Stop()
 
 	call.Checkpoint("checkpointA")
@@ -33,7 +33,7 @@ func traceRoot(ctx context.Context) {
 }
 
 func traceA(ctx context.Context) {
-	call := Fetch(ctx).Start().Mark("A")
+	call := Fetch(ctx).Start("A")
 	defer call.Stop()
 
 	call.Checkpoint("checkpointA1")
@@ -55,7 +55,7 @@ func traceA2(ctx context.Context) {
 }
 
 func traceB(ctx context.Context) {
-	call := Fetch(ctx).Start().Mark("B")
+	call := Fetch(ctx).Start("B")
 	defer call.Stop()
 
 	call.Checkpoint("checkpointB1")

--- a/helper_test.go
+++ b/helper_test.go
@@ -25,10 +25,10 @@ func traceRoot(ctx context.Context) {
 	call := Fetch(ctx).Start().Mark("root")
 	defer call.Stop()
 
-	call.Checkpoint().Mark("checkpointA")
+	call.Checkpoint("checkpointA")
 	traceA(ctx)
 
-	call.Checkpoint().Mark("checkpointB")
+	call.Checkpoint("checkpointB")
 	traceB(ctx)
 }
 
@@ -36,10 +36,10 @@ func traceA(ctx context.Context) {
 	call := Fetch(ctx).Start().Mark("A")
 	defer call.Stop()
 
-	call.Checkpoint().Mark("checkpointA1")
+	call.Checkpoint("checkpointA1")
 	traceA1(ctx)
 
-	call.Checkpoint().Mark("checkpointA2")
+	call.Checkpoint("checkpointA2")
 	traceA2(ctx)
 }
 
@@ -58,10 +58,10 @@ func traceB(ctx context.Context) {
 	call := Fetch(ctx).Start().Mark("B")
 	defer call.Stop()
 
-	call.Checkpoint().Mark("checkpointB1")
+	call.Checkpoint("checkpointB1")
 	traceB1(ctx)
 
-	call.Checkpoint().Mark("checkpointB2")
+	call.Checkpoint("checkpointB2")
 	func(ctx context.Context) {
 		defer Fetch(ctx).Start().Stop()
 	}(ctx)

--- a/tracer.go
+++ b/tracer.go
@@ -71,22 +71,24 @@ type Call struct {
 	caller      CallerInfo
 	start, stop time.Time
 	id          string
-	checkpoints []*Checkpoint
+	checkpoints []Checkpoint
 	allocates   int
 }
 
-func (call *Call) Checkpoint() *Checkpoint {
+func (call *Call) Checkpoint(labels ...string) {
 	if call == nil {
-		return nil
+		return
 	}
 
-	checkpoint := &Checkpoint{timestamp: time.Now()}
+	var id string
+	if len(labels) > 0 {
+		id = labels[0]
+	}
+	checkpoint := Checkpoint{id: id, timestamp: time.Now()}
 	if len(call.checkpoints) == cap(call.checkpoints) {
 		call.allocates++
 	}
 	call.checkpoints = append(call.checkpoints, checkpoint)
-
-	return checkpoint
 }
 
 func (call *Call) Mark(id string) *Call {
@@ -109,12 +111,4 @@ func (call *Call) Stop() {
 type Checkpoint struct {
 	id        string
 	timestamp time.Time
-}
-
-func (checkpoint *Checkpoint) Mark(id string) {
-	if checkpoint == nil {
-		return
-	}
-
-	checkpoint.id = id
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestTrace_Start(t *testing.T) {
-	(*Trace)(nil).Start().Mark("no panic")
-	(&Trace{}).Start().Mark("one allocation")
+	(*Trace)(nil).Start("no panic")
+	(&Trace{}).Start("one allocation")
 }
 
 func TestTrace_String(t *testing.T) {
@@ -26,7 +26,7 @@ func TestTrace_String(t *testing.T) {
 			t.Errorf("\n expected: %+#v \n obtained: %+#v", expected, obtained)
 		}
 
-		call := trace.Start().Mark("fn call")
+		call := trace.Start("fn call")
 		call.Checkpoint("checkpoint")
 		call.Stop()
 		if expected, obtained := "allocates at call stack: 1", trace.String(); !strings.Contains(obtained, expected) {
@@ -35,34 +35,19 @@ func TestTrace_String(t *testing.T) {
 	})
 }
 
-func TestCall_Checkpoint(t *testing.T) {
-	(*Call)(nil).Checkpoint("no panic")
-	(&Call{}).Checkpoint("one allocation")
-}
-
-func TestCall_Mark(t *testing.T) {
-	(*Call)(nil).Mark("no panic")
-	(&Call{}).Mark("by id")
-}
-
-func TestCall_Stop(t *testing.T) {
-	(*Call)(nil).Mark("no panic").Stop()
-	(&Call{}).Mark("success").Stop()
-}
-
-// BenchmarkTracing/silent-12         	  200000	      7755 ns/op	    1816 B/op	      24 allocs/op
-// BenchmarkTracing/full-12           	  200000	      8880 ns/op	    3944 B/op	      45 allocs/op
+// BenchmarkTracing/silent-12         	  200000	      7298 ns/op	    2336 B/op	      18 allocs/op
+// BenchmarkTracing/full-12           	  200000	      8918 ns/op	    4464 B/op	      39 allocs/op
 func BenchmarkTracing(b *testing.B) {
 	b.Run("silent", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			traceRoot(Inject(context.Background(), make([]*Call, 0, 9)))
+			traceRoot(Inject(context.Background(), make([]Call, 0, 9)))
 		}
 	})
 	b.Run("full", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			ctx := Inject(context.Background(), make([]*Call, 0, 9))
+			ctx := Inject(context.Background(), make([]Call, 0, 9))
 			traceRoot(ctx)
 			_ = Fetch(ctx).String()
 		}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -27,7 +27,7 @@ func TestTrace_String(t *testing.T) {
 		}
 
 		call := trace.Start().Mark("fn call")
-		call.Checkpoint().Mark("checkpoint")
+		call.Checkpoint("checkpoint")
 		call.Stop()
 		if expected, obtained := "allocates at call stack: 1", trace.String(); !strings.Contains(obtained, expected) {
 			t.Errorf("\n expected: %+#v \n obtained: %+#v", expected, obtained)
@@ -36,8 +36,8 @@ func TestTrace_String(t *testing.T) {
 }
 
 func TestCall_Checkpoint(t *testing.T) {
-	(*Call)(nil).Checkpoint().Mark("no panic")
-	(&Call{}).Checkpoint().Mark("one allocation")
+	(*Call)(nil).Checkpoint("no panic")
+	(&Call{}).Checkpoint("one allocation")
 }
 
 func TestCall_Mark(t *testing.T) {
@@ -48,11 +48,6 @@ func TestCall_Mark(t *testing.T) {
 func TestCall_Stop(t *testing.T) {
 	(*Call)(nil).Mark("no panic").Stop()
 	(&Call{}).Mark("success").Stop()
-}
-
-func TestCheckpoint_Mark(t *testing.T) {
-	(*Checkpoint)(nil).Mark("no panic")
-	(&Checkpoint{}).Mark("by id")
 }
 
 // BenchmarkTracing/silent-12         	  200000	      7755 ns/op	    1816 B/op	      24 allocs/op


### PR DESCRIPTION
master

```
BenchmarkTracing/silent-12         	  200000	      7755 ns/op	    1816 B/op	      24 allocs/op
BenchmarkTracing/full-12           	  200000	      8880 ns/op	    3944 B/op	      45 allocs/op
```